### PR TITLE
Switch the base image to debian:buster-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:10-slim
-RUN npm install -g firebase-tools
+FROM debian:buster-slim
+RUN apt-get update && apt-get -y install curl sudo
+RUN curl -sL https://firebase.tools | bash
 COPY entrypoint.sh /usr/local/bin
 ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
According to https://github.com/lowply/deploy-firebase/issues/9, `npm install -g firebase-tools` started to fail.

```
$ docker run -it --rm node:14-slim /bin/bash
root@cf9e06bdde6d:/# npm install -g firebase-tools
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.1.2 (node_modules/firebase-tools/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.1.3: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})

npm ERR! code ENOENT
npm ERR! syscall spawn git
npm ERR! path git
npm ERR! errno -2
npm ERR! enoent Error while executing:
npm ERR! enoent undefined ls-remote -h -t ssh://git@github.com/DABH/diagnostics.git
npm ERR! enoent
npm ERR! enoent
npm ERR! enoent spawn git ENOENT
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2020-06-22T15_19_40_461Z-debug.log
```

I don't understand why `npm install` requires `git` to be spawned. Also, the connection between firebase-tools and the `DABH/diagnostics` repository is unclear.

Instead of using npm, I'm switching the base image to `debian:buster-slim` and use [the firebase installation script](https://firebase.google.com/docs/cli#install-cli-mac-linux).

fixes https://github.com/lowply/deploy-firebase/issues/9