### PR TITLE
:boom: deploy all firebase assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Deploy to Firebase
 
-A GitHub Action to deploy to Firebase Hosting.
+A GitHub Action to deploy to Firebase.
 
 - Make sure that you checkout the repository using the [actions/checkout](https://github.com/actions/checkout) action
 - Make sure that you have the `firebase.json` file in the repository
 - To obtain the Firebase token, run `firebase login:ci` on your local computer and [store the token](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) as the `FIREBASE_TOKEN` secret
 - Specify the Firebase project name in the `FIREBASE_PROJECT` env var
+- If you would like to deploy only hosting, set `FIREBASE_ONLY_HOSTING` to true
 
 ## Workflow examples
 
@@ -47,4 +48,5 @@ jobs:
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         FIREBASE_PROJECT: name-of-the-project
+        FIREBASE_ONLY_HOSTING: true
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,14 @@ if [ -z "${FIREBASE_PROJECT}" ]; then
     echo "FIREBASE_PROJECT is missing"
     exit 1
 fi
-
-firebase deploy \
+if [ -z "${FIREBASE_ONLY_HOSTING}" ]; then
+    firebase deploy \
     -m "${GITHUB_REF} (${GITHUB_SHA})" \
     --project ${FIREBASE_PROJECT} \
     --only hosting
+    exit 0
+fi
+
+firebase deploy \
+    -m "${GITHUB_REF} (${GITHUB_SHA})" \
+    --project ${FIREBASE_PROJECT}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ if [ -z "${FIREBASE_PROJECT}" ]; then
     echo "FIREBASE_PROJECT is missing"
     exit 1
 fi
-if [ -z "${FIREBASE_ONLY_HOSTING}" ]; then
+if [ -z "${FIREBASE_ONLY_HOSTING}" == "true" ]; then
     firebase deploy \
     -m "${GITHUB_REF} (${GITHUB_SHA})" \
     --project ${FIREBASE_PROJECT} \


### PR DESCRIPTION
Allow override for hosting only - FIREBASE_ONLY_HOSTING

I'm aware that this is a breaking change, however there's currently no other action that handles this. Happy to keep this as a fork if you don't want it

:memo: updated documentation
🚀 Tested and in use
Associated issue https://github.com/lowply/deploy-firebase/issues/19

If anyone wants to use this before merge, you can like so: ` - uses: elmarti/deploy-firebase@main`
CC @DouglasCF